### PR TITLE
Allow specifying SPI mode in certain cases

### DIFF
--- a/Adafruit_GC9A01A.cpp
+++ b/Adafruit_GC9A01A.cpp
@@ -99,6 +99,7 @@ Adafruit_GC9A01A::Adafruit_GC9A01A(int8_t cs, int8_t dc, int8_t rst)
     @param  cs        Chip select pin # (optional, pass -1 if unused and
                       CS is tied to GND).
     @param  rst       Reset pin # (optional, pass -1 if unused).
+    @param  mode      SPI mode (optional, defaults to SPI_MODE0 if unspecified).
 */
 Adafruit_GC9A01A::Adafruit_GC9A01A(SPIClass *spiClass, int8_t dc, int8_t cs,
                                    int8_t rst, uint8_t mode)

--- a/Adafruit_GC9A01A.cpp
+++ b/Adafruit_GC9A01A.cpp
@@ -101,9 +101,10 @@ Adafruit_GC9A01A::Adafruit_GC9A01A(int8_t cs, int8_t dc, int8_t rst)
     @param  rst       Reset pin # (optional, pass -1 if unused).
 */
 Adafruit_GC9A01A::Adafruit_GC9A01A(SPIClass *spiClass, int8_t dc, int8_t cs,
-                                   int8_t rst)
+                                   int8_t rst, uint8_t mode)
     : Adafruit_SPITFT(GC9A01A_TFTWIDTH, GC9A01A_TFTHEIGHT, spiClass, cs, dc,
-                      rst) {}
+                      rst),
+      spi_mode(mode) {}
 #endif // end !ESP8266
 
 /*!
@@ -196,7 +197,8 @@ void Adafruit_GC9A01A::begin(uint32_t freq) {
 
   if (!freq)
     freq = SPI_DEFAULT_FREQ;
-  initSPI(freq);
+
+  initSPI(freq, spi_mode);
 
   if (_rst < 0) {                 // If no hardware reset pin...
     sendCommand(GC9A01A_SWRESET); // Engage software reset

--- a/Adafruit_GC9A01A.h
+++ b/Adafruit_GC9A01A.h
@@ -134,5 +134,5 @@ private:
   // to the GC9A01A constructor that starts with an spiClass argument. This
   // should have no impact on existing code, which will continue using SPI
   // mode 0 as always!
-  uint8_t spi_mode = SPI_MODE0; // Save SPI mode from constructor to initSPI()
+  uint8_t spi_mode = SPI_MODE0; ///< Save SPI mode from constructor to initSPI()
 };

--- a/Adafruit_GC9A01A.h
+++ b/Adafruit_GC9A01A.h
@@ -108,7 +108,7 @@ public:
   Adafruit_GC9A01A(int8_t _CS, int8_t _DC, int8_t _RST = -1);
 #if !defined(ESP8266)
   Adafruit_GC9A01A(SPIClass *spiClass, int8_t dc, int8_t cs = -1,
-                   int8_t rst = -1);
+                   int8_t rst = -1, uint8_t mode = SPI_MODE0);
 #endif // end !ESP8266
   Adafruit_GC9A01A(tftBusWidth busWidth, int8_t d0, int8_t wr, int8_t dc,
                    int8_t cs = -1, int8_t rst = -1, int8_t rd = -1);
@@ -118,4 +118,21 @@ public:
   void invertDisplay(bool i);
 
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+
+private:
+  // For applictions that are constrained by SPI bandwidth (rather than render
+  // cycles), shenanigans are possible with RP2XXX chips and certain displays
+  // by using SPI_MODE3 to eke out a few extra percent throughput. Small but
+  // quantifiable and perceptible. Explained here:
+  // raspberrypi.stackexchange.com/questions/132758/what-is-the-pico-max-spi-frequency
+  // Although initSPI() in Adafruit_SPITFT accepts an SPI mode argument, the
+  // user-facing begin() function provided by SPITFT subclasses is a virtual
+  // function accepting a single argument (freq), and adding a second argument
+  // (even if optional) would require updating EVERY SPITFT subclass and make
+  // a lot of people very frustrated. Given how super esoteric this is, a
+  // workaround here is to allow SPI mode as an optional argument specifically
+  // to the GC9A01A constructor that starts with an spiClass argument. This
+  // should have no impact on existing code, which will continue using SPI
+  // mode 0 as always!
+  uint8_t spi_mode = SPI_MODE0; // Save SPI mode from constructor to initSPI()
 };

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit GC9A01A
-version=1.1.1
+version=1.1.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for GC9A01A displays


### PR DESCRIPTION
Esoteric but beneficial; use case and background are commented in .h

Basically: a rare situation can benefit this display by using SPI_MODE3, but (see comments) adding this via Adafruit_GFX/SPITFT would break a TON of libraries. This PR allows optionally specifying SPI mode through one of the constructors. As it's an optional trailing arg, this should not impact any existing code. Also library minor version is bumped to indicate this change.